### PR TITLE
[Feat] 키워드 선택 컴포넌트 구현

### DIFF
--- a/src/assets/svgs/Polygon-down.svg
+++ b/src/assets/svgs/Polygon-down.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Polygon 4" d="M5 6L-4.29138e-07 -3.97391e-07L10 4.76837e-07L5 6Z" fill="#282828"/>
+</svg>

--- a/src/components/common/selectKeyword/forStudent/SelectKeyword.jsx
+++ b/src/components/common/selectKeyword/forStudent/SelectKeyword.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import {
+  KeywordContainer,
+  CustomSelect,
+  SelectList,
+  SelectItem,
+} from './index.style';
+import KEYWORDS from '@utils/constants/keyword';
+import ArrowIcon from '@svgs/Polygon-down.svg?react';
+
+const keywordLabels = {
+  grade: '성적',
+  attendance: '출석',
+  assignment: '과제',
+  class: '수강',
+};
+
+const SelectKeyword = () => {
+  const [selectedKeyword, setSelectedKeyword] = useState('');
+  const [isKeywordOpen, setIsKeywordOpen] = useState(false);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const [selectedDetailKeyword, setSelectedDetailKeyword] = useState('');
+
+  const handleKeywordSelect = (value) => {
+    setSelectedKeyword(value);
+    setSelectedDetailKeyword('');
+    setIsKeywordOpen(false);
+  };
+
+  const handleDetailSelect = (value) => {
+    setSelectedDetailKeyword(value);
+    setIsDetailOpen(false);
+  };
+
+  return (
+    <>
+      <KeywordContainer>
+        <label htmlFor="keyword-select">키워드</label>
+        <CustomSelect onClick={() => setIsKeywordOpen(!isKeywordOpen)}>
+          <span>
+            {selectedKeyword ? keywordLabels[selectedKeyword] : '키워드 선택'}
+          </span>
+          <ArrowIcon />
+        </CustomSelect>
+        {isKeywordOpen && (
+          <SelectList>
+            {Object.keys(KEYWORDS.STUDENT_KEYWORDS)
+              .filter((key) => key !== '')
+              .map((key, index, array) => (
+                <>
+                  <SelectItem
+                    key={key}
+                    onClick={() => handleKeywordSelect(key)}
+                  >
+                    {keywordLabels[key]}
+                  </SelectItem>
+                  {index < array.length - 1 && <div className="divider" />}
+                </>
+              ))}
+          </SelectList>
+        )}
+      </KeywordContainer>
+      <KeywordContainer>
+        <label htmlFor="detail-keyword-select">세부 키워드</label>
+        <CustomSelect onClick={() => setIsDetailOpen(!isDetailOpen)}>
+          <span>
+            {selectedDetailKeyword ? selectedDetailKeyword : '세부 키워드 선택'}
+          </span>
+          <ArrowIcon />
+        </CustomSelect>
+        {isDetailOpen && selectedKeyword && (
+          <SelectList>
+            {KEYWORDS.STUDENT_KEYWORDS[selectedKeyword].map(
+              (option, index, array) => (
+                <>
+                  <SelectItem
+                    key={option.value}
+                    onClick={() => handleDetailSelect(option.label)}
+                  >
+                    {option.label}
+                  </SelectItem>
+                  {index < array.length - 1 && <div className="divider" />}
+                </>
+              ),
+            )}
+          </SelectList>
+        )}
+      </KeywordContainer>
+    </>
+  );
+};
+
+export default SelectKeyword;

--- a/src/components/common/selectKeyword/forStudent/index.style.js
+++ b/src/components/common/selectKeyword/forStudent/index.style.js
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const KeywordContainer = styled.section`
+  display: flex;
+  width: 148px;
+  height: 200px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  position: relative;
+
+  label {
+    margin-bottom: 10px;
+    font-family: ${theme.font.family};
+    font-size: ${theme.font.size.medium};
+    font-weight: ${theme.font.weight.bold};
+    color: ${theme.colors.black2};
+  }
+`;
+
+export const CustomSelect = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+  padding: 8px 10px;
+
+  border-radius: 6px;
+  border: 1px solid ${theme.colors.gray3};
+  background-color: ${theme.colors.white};
+  font-size: ${theme.font.size.small};
+  font-weight: ${theme.font.weight.medium};
+`;
+
+export const SelectList = styled.ul`
+  display: block;
+  width: 100%;
+  position: absolute;
+  top: 34%;
+  left: 0;
+  max-height: 128px;
+
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray3};
+  border-radius: 6px;
+
+  .divider {
+    height: 1px;
+    width: 100%;
+    background-color: ${theme.colors.gray3};
+  }
+`;
+
+export const SelectItem = styled.li`
+  display: flex;
+  position: relative;
+  align-items: center;
+  padding: 8px 10px;
+
+  font-size: ${theme.font.size.small};
+  font-weight: ${theme.font.weight.medium};
+  color: ${theme.colors.black2};
+  background-color: ${theme.colors.white};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.colors.gray1};
+  }
+`;

--- a/src/components/common/selectKeyword/forWorker/SelectKeyword.jsx
+++ b/src/components/common/selectKeyword/forWorker/SelectKeyword.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import {
+  KeywordContainer,
+  CustomSelect,
+  SelectList,
+  SelectItem,
+} from './index.style';
+import KEYWORDS from '@utils/constants/keyword';
+import ArrowIcon from '@svgs/Polygon-down.svg?react';
+
+const keywordLabels = {
+  boss: '상사',
+  coWorker: '동료',
+};
+
+const SelectKeyword = () => {
+  const [selectedKeyword, setSelectedKeyword] = useState('');
+  const [isKeywordOpen, setIsKeywordOpen] = useState(false);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const [selectedDetailKeyword, setSelectedDetailKeyword] = useState('');
+
+  const handleKeywordSelect = (value) => {
+    setSelectedKeyword(value);
+    setSelectedDetailKeyword('');
+    setIsKeywordOpen(false);
+  };
+
+  const handleDetailSelect = (value) => {
+    setSelectedDetailKeyword(value);
+    setIsDetailOpen(false);
+  };
+
+  return (
+    <>
+      <KeywordContainer>
+        <label htmlFor="keyword-select">키워드</label>
+        <CustomSelect onClick={() => setIsKeywordOpen(!isKeywordOpen)}>
+          <span>
+            {selectedKeyword ? keywordLabels[selectedKeyword] : '키워드 선택'}
+          </span>
+          <ArrowIcon />
+        </CustomSelect>
+        {isKeywordOpen && (
+          <SelectList>
+            {Object.keys(KEYWORDS.WORKER_KEYWORDS)
+              .filter((key) => key !== '')
+              .map((key, index, array) => (
+                <>
+                  <SelectItem
+                    key={key}
+                    onClick={() => handleKeywordSelect(key)}
+                  >
+                    {keywordLabels[key]}
+                  </SelectItem>
+                  {index < array.length - 1 && <div className="divider" />}
+                </>
+              ))}
+          </SelectList>
+        )}
+      </KeywordContainer>
+      <KeywordContainer>
+        <label htmlFor="detail-keyword-select">세부 키워드</label>
+        <CustomSelect onClick={() => setIsDetailOpen(!isDetailOpen)}>
+          <span>
+            {selectedDetailKeyword ? selectedDetailKeyword : '세부 키워드 선택'}
+          </span>
+          <ArrowIcon />
+        </CustomSelect>
+        {isDetailOpen && selectedKeyword && (
+          <SelectList>
+            {KEYWORDS.WORKER_KEYWORDS[selectedKeyword].map(
+              (option, index, array) => (
+                <>
+                  <SelectItem
+                    key={option.value}
+                    onClick={() => handleDetailSelect(option.label)}
+                  >
+                    {option.label}
+                  </SelectItem>
+                  {index < array.length - 1 && <div className="divider" />}
+                </>
+              ),
+            )}
+          </SelectList>
+        )}
+      </KeywordContainer>
+    </>
+  );
+};
+
+export default SelectKeyword;

--- a/src/components/common/selectKeyword/forWorker/index.style.js
+++ b/src/components/common/selectKeyword/forWorker/index.style.js
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+export const KeywordContainer = styled.section`
+  display: flex;
+  width: 148px;
+  height: 200px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  position: relative;
+
+  label {
+    margin-bottom: 10px;
+    font-family: ${theme.font.family};
+    font-size: ${theme.font.size.medium};
+    font-weight: ${theme.font.weight.bold};
+    color: ${theme.colors.black2};
+  }
+`;
+
+export const CustomSelect = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+  padding: 8px 10px;
+
+  border-radius: 6px;
+  border: 1px solid ${theme.colors.gray3};
+  background-color: ${theme.colors.white};
+  font-size: ${theme.font.size.small};
+  font-weight: ${theme.font.weight.medium};
+`;
+
+export const SelectList = styled.ul`
+  display: block;
+  width: 100%;
+  position: absolute;
+  top: 34%;
+  left: 0;
+  max-height: 128px;
+
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray3};
+  border-radius: 6px;
+
+  .divider {
+    height: 1px;
+    width: 100%;
+    background-color: ${theme.colors.gray3};
+  }
+`;
+
+export const SelectItem = styled.li`
+  display: flex;
+  position: relative;
+  align-items: center;
+  padding: 8px 10px;
+
+  font-size: ${theme.font.size.small};
+  font-weight: ${theme.font.weight.medium};
+  color: ${theme.colors.black2};
+  background-color: ${theme.colors.white};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.colors.gray1};
+  }
+`;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -7,6 +7,7 @@ const theme = {
     gray: '#848688',
     gray1: 'rgba(229, 229, 229, 0.60)',
     gray2: 'rgba(40, 40, 40, 0.70)',
+    gray3: '#CCCCCC',
     red: '#FF4864',
     red_hover: 'rgba(255, 72, 100, 0.65)',
     pink: '#FFC9D1',
@@ -26,6 +27,7 @@ const theme = {
       black: 900,
     },
     size: {
+      xSmall: '10px',
       small: '12px',
       medium: '16px',
       large: '20px',

--- a/src/test/index.jsx
+++ b/src/test/index.jsx
@@ -1,13 +1,27 @@
 // 컴포넌트 테스트 용
 import { ComponentSection, SubTitle } from './index.style';
+import StudentSelectKeyword from '@components/common/selectKeyword/forStudent/SelectKeyword';
+import WorkerSelectKeyword from '@components/common/selectKeyword/forWorker/SelectKeyword';
+
 import AISubmitBtn from '@/components/common/aiSubmitButton/AISubmitBtn';
 
 const index = () => {
   return (
-    <ComponentSection>
-      <SubTitle>AI 생성 전송 버튼</SubTitle>
-      <AISubmitBtn />
-    </ComponentSection>
+    <>
+      <ComponentSection>
+        <SubTitle>키워드 선택 (학생) </SubTitle>
+        <StudentSelectKeyword />
+      </ComponentSection>
+      <ComponentSection>
+        <SubTitle>키워드 선택 (직장인) </SubTitle>
+        <WorkerSelectKeyword />
+      </ComponentSection>
+
+      <ComponentSection>
+        <SubTitle>AI 생성 전송 버튼</SubTitle>
+        <AISubmitBtn />
+      </ComponentSection>
+    </>
   );
 };
 

--- a/src/test/index.style.js
+++ b/src/test/index.style.js
@@ -6,7 +6,7 @@ export const ComponentSection = styled.section`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 10px;
 `;
 
 export const SubTitle = styled.h3`

--- a/src/utils/constants/keyword.js
+++ b/src/utils/constants/keyword.js
@@ -1,0 +1,38 @@
+export const STUDENT_KEYWORDS = {
+  '': [],
+  grade: [
+    { value: 'grade-correction', label: '성적 정정' },
+    { value: 'grade-inquiry', label: '성적 문의' },
+  ],
+  attendance: [
+    { value: 'attendance-confirmation', label: '출석 확인' },
+    { value: 'attendance-late', label: '지각' },
+    { value: 'attendance-absence', label: '결석' },
+  ],
+  assignment: [
+    { value: 'assignment-confirmation-of-submission', label: '제출 확인' },
+    { value: 'assignment-Inquiry', label: '과제 문의' },
+  ],
+  class: [
+    { value: 'class-Inquiry', label: '수강 문의' },
+    { value: 'class-additional', label: '추가 수강' },
+  ],
+};
+
+export const WORKER_KEYWORDS = {
+  '': [],
+  boss: [
+    { value: 'request-vacation', label: '휴가 요청' },
+    { value: 'charge-for-expenses', label: '비용 청구' },
+    { value: 'business-report', label: '업무 보고' },
+    { value: 'request-for-consultation', label: '상담 요청' },
+  ],
+  coWorker: [
+    { value: 'check-work', label: '업무 확인' },
+    { value: 'conference-coordination', label: '회의 조율' },
+    { value: 'request-for-feedback', label: '피드백 요청' },
+  ],
+};
+
+const KEYWORDS = { STUDENT_KEYWORDS, WORKER_KEYWORDS };
+export default KEYWORDS;

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
       '@components': path.resolve(__dirname, 'src/components'),
       '@pages': path.resolve(__dirname, 'src/pages'),
       '@styles': path.resolve(__dirname, 'src/styles'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
       '@test': path.resolve(__dirname, 'src/test'),
     },
     extensions: ['.js', '.jsx', '.svg', '.png', '.jpg'],


### PR DESCRIPTION
키워드 선택 컴포넌트를 학생 대상과 직장인 대상으로 나누어 구현했습니다.
추후 대상 선택 버튼과 연결해 알맞은 컴포넌트 렌더링 되도록 할 예정입니다.
아래는 /test 페이지에서 확인 가능한 구현 결과입니다.
<br/>

**구현결과** 
|  학생 키워드 선택 컴포넌트           | 직장인 키워드 선택 컴포넌트                   |
|-----------------|------------------------|
|    <img width="170" alt="학생 키워드 선택 컴포넌트" src="https://github.com/user-attachments/assets/7a32a63b-20a1-4144-b18e-77224d038f39" />    | <img width="166" alt="직장인 키워드 선택 컴포넌트" src="https://github.com/user-attachments/assets/2cf7ed8c-6fe9-40b2-9d66-a77fb2c6809d" />
