### PR TITLE
[Feat] 메일 템플릿 작성 페이지 구현

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from '@pages/home';
 import Test from '@pages/test';
-import MailTemplate from '@pages/mailTemplate/mailTemplate';
+import MailTemplate from '@/pages/mailTemplate/templatePage';
 import MailAI from '@pages/mailAI/mailAI';
 import MailManually from '@pages/mailManually/mailManually';
 

--- a/src/components/common/selectKeyword/forStudent/SelectKeyword.jsx
+++ b/src/components/common/selectKeyword/forStudent/SelectKeyword.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import {
   KeywordContainer,
   CustomSelect,
@@ -15,20 +15,23 @@ const keywordLabels = {
   class: '수강',
 };
 
-const SelectKeyword = () => {
-  const [selectedKeyword, setSelectedKeyword] = useState('');
+const SelectKeyword = ({
+  selectedKeyword,
+  setSelectedKeyword,
+  selectedDetail,
+  setSelectedDetail,
+}) => {
   const [isKeywordOpen, setIsKeywordOpen] = useState(false);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const [selectedDetailKeyword, setSelectedDetailKeyword] = useState('');
 
   const handleKeywordSelect = (value) => {
     setSelectedKeyword(value);
-    setSelectedDetailKeyword('');
+    setSelectedDetail('');
     setIsKeywordOpen(false);
   };
 
   const handleDetailSelect = (value) => {
-    setSelectedDetailKeyword(value);
+    setSelectedDetail(value);
     setIsDetailOpen(false);
   };
 
@@ -47,7 +50,7 @@ const SelectKeyword = () => {
             {Object.keys(KEYWORDS.STUDENT_KEYWORDS)
               .filter((key) => key !== '')
               .map((key, index, array) => (
-                <>
+                <Fragment key={key}>
                   <SelectItem
                     key={key}
                     onClick={() => handleKeywordSelect(key)}
@@ -55,7 +58,7 @@ const SelectKeyword = () => {
                     {keywordLabels[key]}
                   </SelectItem>
                   {index < array.length - 1 && <div className="divider" />}
-                </>
+                </Fragment>
               ))}
           </SelectList>
         )}
@@ -63,9 +66,7 @@ const SelectKeyword = () => {
       <KeywordContainer>
         <label htmlFor="detail-keyword-select">세부 키워드</label>
         <CustomSelect onClick={() => setIsDetailOpen(!isDetailOpen)}>
-          <span>
-            {selectedDetailKeyword ? selectedDetailKeyword : '세부 키워드 선택'}
-          </span>
+          <span>{selectedDetail || '세부 키워드 선택'}</span>
           <ArrowIcon />
         </CustomSelect>
         {isDetailOpen && selectedKeyword && (

--- a/src/components/common/selectKeyword/forStudent/index.style.js
+++ b/src/components/common/selectKeyword/forStudent/index.style.js
@@ -7,8 +7,9 @@ export const KeywordContainer = styled.section`
   height: 200px;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;
+  gap: 7px;
   position: relative;
+  margin-top: 20px;
 
   label {
     margin-bottom: 10px;

--- a/src/components/common/selectKeyword/forWorker/SelectKeyword.jsx
+++ b/src/components/common/selectKeyword/forWorker/SelectKeyword.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import {
   KeywordContainer,
   CustomSelect,
@@ -13,20 +13,23 @@ const keywordLabels = {
   coWorker: '동료',
 };
 
-const SelectKeyword = () => {
-  const [selectedKeyword, setSelectedKeyword] = useState('');
+const SelectKeyword = ({
+  selectedKeyword,
+  setSelectedKeyword,
+  selectedDetail,
+  setSelectedDetail,
+}) => {
   const [isKeywordOpen, setIsKeywordOpen] = useState(false);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
-  const [selectedDetailKeyword, setSelectedDetailKeyword] = useState('');
 
   const handleKeywordSelect = (value) => {
     setSelectedKeyword(value);
-    setSelectedDetailKeyword('');
+    setSelectedDetail('');
     setIsKeywordOpen(false);
   };
 
   const handleDetailSelect = (value) => {
-    setSelectedDetailKeyword(value);
+    setSelectedDetail(value);
     setIsDetailOpen(false);
   };
 
@@ -45,7 +48,7 @@ const SelectKeyword = () => {
             {Object.keys(KEYWORDS.WORKER_KEYWORDS)
               .filter((key) => key !== '')
               .map((key, index, array) => (
-                <>
+                <Fragment key={key}>
                   <SelectItem
                     key={key}
                     onClick={() => handleKeywordSelect(key)}
@@ -53,7 +56,7 @@ const SelectKeyword = () => {
                     {keywordLabels[key]}
                   </SelectItem>
                   {index < array.length - 1 && <div className="divider" />}
-                </>
+                </Fragment>
               ))}
           </SelectList>
         )}
@@ -61,9 +64,7 @@ const SelectKeyword = () => {
       <KeywordContainer>
         <label htmlFor="detail-keyword-select">세부 키워드</label>
         <CustomSelect onClick={() => setIsDetailOpen(!isDetailOpen)}>
-          <span>
-            {selectedDetailKeyword ? selectedDetailKeyword : '세부 키워드 선택'}
-          </span>
+          <span>{selectedDetail || '세부 키워드 선택'}</span>
           <ArrowIcon />
         </CustomSelect>
         {isDetailOpen && selectedKeyword && (

--- a/src/components/common/sideBar/SideBar.jsx
+++ b/src/components/common/sideBar/SideBar.jsx
@@ -21,7 +21,7 @@ const Sidebar = () => {
 
   return (
     <SidebarContainer>
-      <Logo>
+      <Logo onClick={() => navigate('/')}>
         <LogoImage />
       </Logo>
       <MenuList>

--- a/src/components/common/sideBar/index.style.js
+++ b/src/components/common/sideBar/index.style.js
@@ -15,6 +15,7 @@ export const Logo = styled.div`
   display: flex;
   margin: 27px 77px 46px 10px;
   width: 93px;
+  cursor: pointer;
 `;
 
 export const LogoImage = styled(MailerLogo)`

--- a/src/components/common/targetButton/TargetBtn.jsx
+++ b/src/components/common/targetButton/TargetBtn.jsx
@@ -1,22 +1,19 @@
-import { useState } from 'react';
 import { Title, ButtonContainer, StyledButton } from './index.style';
 
-const TargetBtn = () => {
-  const [selected, setSelected] = useState(null);
-
+const TargetBtn = ({ selected, onSelect }) => {
   return (
     <>
-      <Title>직업</Title>
+      <Title>대상</Title>
       <ButtonContainer>
         <StyledButton
           $isSelected={selected === '학생'}
-          onClick={() => setSelected('학생')}
+          onClick={() => onSelect('학생')}
         >
           학생
         </StyledButton>
         <StyledButton
           $isSelected={selected === '직장인'}
-          onClick={() => setSelected('직장인')}
+          onClick={() => onSelect('직장인')}
         >
           직장인
         </StyledButton>

--- a/src/pages/mailTemplate/components/mailEditor/MailEditor.jsx
+++ b/src/pages/mailTemplate/components/mailEditor/MailEditor.jsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import {
+  EditorContainer,
+  TopArea,
+  InputWrapper,
+  Label,
+  Input,
+  MainArea,
+  Textarea,
+  BottomArea,
+  BottomLeft,
+  BottomRight,
+} from './index.style';
+
+import FileInput from '@components/common/fileInput/FileInput';
+import SubmitBtn from '@components/common/submitBtn/SubmitBtn';
+import AIPopUp from '@components/common/aiPopUp/AIPopUp';
+
+const MailEditor = ({ templateContent }) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleSave = () => {
+    // 메일 임시저장 로직 작성 예정
+  };
+
+  const handleSend = () => {
+    setShowModal(true);
+    // 메일 전송 로직 작성 예정
+  };
+
+  return (
+    <>
+      <EditorContainer>
+        {/* 수신자 정보 입력 영역 */}
+        <TopArea>
+          <InputWrapper>
+            <Label>받는 사람 :</Label>
+            <Input placeholder="수신자 이메일 입력" />
+          </InputWrapper>
+
+          <InputWrapper>
+            <Label>제목 :</Label>
+            <Input placeholder="메일 제목 입력" />
+          </InputWrapper>
+
+          <InputWrapper>
+            <Label>보낸 사람 :</Label>
+            <Input placeholder="발신자 이메일 입력" />
+          </InputWrapper>
+        </TopArea>
+
+        {/* 본문 영역 */}
+        <MainArea>
+          <Textarea readOnly value={templateContent} />
+        </MainArea>
+
+        {/* 하단: 파일 첨부 + 버튼 */}
+        <BottomArea>
+          <BottomLeft>
+            <FileInput width="930px" />
+          </BottomLeft>
+          <BottomRight>
+            <SubmitBtn onSave={handleSave} onSend={handleSend} />
+          </BottomRight>
+        </BottomArea>
+      </EditorContainer>
+
+      {/* AI 피드백 모달 */}
+      {showModal && <AIPopUp onClose={() => setShowModal(false)} />}
+    </>
+  );
+};
+
+export default MailEditor;

--- a/src/pages/mailTemplate/components/mailEditor/index.style.js
+++ b/src/pages/mailTemplate/components/mailEditor/index.style.js
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const EditorContainer = styled.section`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  background-color: ${theme.colors.white};
+  gap: 30px;
+`;
+
+export const TopArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${theme.colors.white1};
+  border-radius: 12px;
+  padding: 16px;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 15px 0;
+  gap: 10px;
+  border-bottom: 1px solid ${theme.colors.gray3};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const Label = styled.label`
+  font-family: ${theme.font.family.basic};
+  font-weight: ${theme.font.weight.medium};
+  font-size: ${theme.font.size.medium};
+  color: ${theme.colors.black2};
+`;
+
+export const Input = styled.input`
+  flex: 1;
+  font-family: ${theme.font.family.basic};
+  font-weight: ${theme.font.weight.medium};
+  font-size: ${theme.font.size.medium};
+  color: ${theme.colors.black2};
+  border: none;
+  background-color: transparent;
+  outline: none;
+
+  &::placeholder {
+    color: ${theme.colors.gray2};
+  }
+`;
+
+export const MainArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${theme.colors.white1};
+  border-radius: 12px;
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  height: 580px;
+  border: none;
+  border-radius: 12px;
+  background-color: ${theme.colors.white1};
+  padding: 24px;
+  color: ${theme.colors.black1};
+  font-family: ${theme.font.family.basic};
+  font-weight: ${theme.font.weight.regular};
+  font-size: ${theme.font.size.sMedium};
+`;
+
+export const BottomArea = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
+
+export const BottomLeft = styled.div`
+  display: flex;
+  align-items: center;
+  margin-right: 52px;
+`;
+
+export const BottomRight = styled.div`
+  display: flex;
+`;

--- a/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
+++ b/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
@@ -6,6 +6,7 @@ import SelectKeywordWorker from '@components/common/selectKeyword/forWorker/Sele
 import {
   SidebarContainer,
   SectionTitle,
+  TargetBox,
   KeywordContainer,
 } from './index.style';
 
@@ -15,9 +16,9 @@ const TemplateSidebar = () => {
   return (
     <SidebarContainer>
       <SectionTitle>템플릿</SectionTitle>
-
-      <TargetBtn selected={selectedTarget} onSelect={setSelectedTarget} />
-
+      <TargetBox>
+        <TargetBtn selected={selectedTarget} onSelect={setSelectedTarget} />
+      </TargetBox>
       <KeywordContainer>
         {selectedTarget === '학생' ? (
           <SelectKeywordStudent />

--- a/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
+++ b/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import TargetBtn from '@components/common/targetButton/TargetBtn';
 import SelectKeywordStudent from '@components/common/selectKeyword/forStudent/SelectKeyword';
 import SelectKeywordWorker from '@components/common/selectKeyword/forWorker/SelectKeyword';
@@ -10,9 +9,14 @@ import {
   KeywordContainer,
 } from './index.style';
 
-const TemplateSidebar = () => {
-  const [selectedTarget, setSelectedTarget] = useState('학생'); // 기본값: 학생
-
+const TemplateSidebar = ({
+  selectedTarget,
+  setSelectedTarget,
+  selectedKeyword,
+  setSelectedKeyword,
+  selectedDetail,
+  setSelectedDetail,
+}) => {
   return (
     <SidebarContainer>
       <SectionTitle>템플릿</SectionTitle>
@@ -21,9 +25,19 @@ const TemplateSidebar = () => {
       </TargetBox>
       <KeywordContainer>
         {selectedTarget === '학생' ? (
-          <SelectKeywordStudent />
+          <SelectKeywordStudent
+            selectedKeyword={selectedKeyword}
+            setSelectedKeyword={setSelectedKeyword}
+            selectedDetail={selectedDetail}
+            setSelectedDetail={setSelectedDetail}
+          />
         ) : (
-          <SelectKeywordWorker />
+          <SelectKeywordWorker
+            selectedKeyword={selectedKeyword}
+            setSelectedKeyword={setSelectedKeyword}
+            selectedDetail={selectedDetail}
+            setSelectedDetail={setSelectedDetail}
+          />
         )}
       </KeywordContainer>
     </SidebarContainer>

--- a/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
+++ b/src/pages/mailTemplate/components/templateSidebar/TemplateSidebar.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import TargetBtn from '@components/common/targetButton/TargetBtn';
+import SelectKeywordStudent from '@components/common/selectKeyword/forStudent/SelectKeyword';
+import SelectKeywordWorker from '@components/common/selectKeyword/forWorker/SelectKeyword';
+
+import {
+  SidebarContainer,
+  SectionTitle,
+  KeywordContainer,
+} from './index.style';
+
+const TemplateSidebar = () => {
+  const [selectedTarget, setSelectedTarget] = useState('학생'); // 기본값: 학생
+
+  return (
+    <SidebarContainer>
+      <SectionTitle>템플릿</SectionTitle>
+
+      <TargetBtn selected={selectedTarget} onSelect={setSelectedTarget} />
+
+      <KeywordContainer>
+        {selectedTarget === '학생' ? (
+          <SelectKeywordStudent />
+        ) : (
+          <SelectKeywordWorker />
+        )}
+      </KeywordContainer>
+    </SidebarContainer>
+  );
+};
+
+export default TemplateSidebar;

--- a/src/pages/mailTemplate/components/templateSidebar/index.style.js
+++ b/src/pages/mailTemplate/components/templateSidebar/index.style.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const SidebarContainer = styled.section`
+  width: 200px;
+  height: 100%;
+  padding: 35px 24px 0 24px;
+  background-color: ${theme.colors.white1};
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SectionTitle = styled.h2`
+  font-size: ${theme.font.size.medium};
+  font-weight: ${theme.font.weight.bold};
+  color: ${theme.colors.black2};
+  margin: 20px 0 8px;
+`;
+
+export const KeywordContainer = styled.div`
+  margin-top: 16px;
+`;

--- a/src/pages/mailTemplate/components/templateSidebar/index.style.js
+++ b/src/pages/mailTemplate/components/templateSidebar/index.style.js
@@ -10,13 +10,17 @@ export const SidebarContainer = styled.section`
   flex-direction: column;
 `;
 
-export const SectionTitle = styled.h2`
-  font-size: ${theme.font.size.medium};
-  font-weight: ${theme.font.weight.bold};
+export const SectionTitle = styled.h1`
   color: ${theme.colors.black2};
-  margin: 20px 0 8px;
+  font-family: ${theme.font.family.basic};
+  font-weight: ${theme.font.weight.bold};
+  font-size: ${theme.font.size.large};
+`;
+
+export const TargetBox = styled.div`
+  margin: 32px 0;
 `;
 
 export const KeywordContainer = styled.div`
-  margin-top: 16px;
+  margin-top: 28px;
 `;

--- a/src/pages/mailTemplate/mailTemplate.jsx
+++ b/src/pages/mailTemplate/mailTemplate.jsx
@@ -1,5 +1,0 @@
-const mailTemplate = () => {
-  return <div>템플릿 작성 페이지</div>;
-};
-
-export default mailTemplate;

--- a/src/pages/mailTemplate/templatePage.jsx
+++ b/src/pages/mailTemplate/templatePage.jsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import Sidebar from '@components/common/sidebar/Sidebar';
+import TemplateSidebar from './components/templateSidebar/TemplateSidebar';
+import MailEditor from './components/mailEditor/MailEditor';
+
+const TemplatePage = () => {
+  const [selectedTarget, setSelectedTarget] = useState('학생');
+  const [selectedKeyword, setSelectedKeyword] = useState('');
+  const [selectedDetail, setSelectedDetail] = useState('');
+  const [templateContent, setTemplateContent] = useState('');
+
+  const isKeywordSelected = selectedKeyword && selectedDetail;
+
+  useEffect(() => {
+    if (isKeywordSelected) {
+      // 임시 템플릿 내용
+      setTemplateContent(`
+        안녕하세요 [교수님 이름],
+        저는 [학과명] [학번] [본인이름]입니다.
+
+        다름이 아니라, [상황 설명]으로 인해 수업에 참석하지 못할 것 같습니다.
+        다른 날짜로 조정이 불가피한 상황이라, 출석 인정 받을 수 있는 다른 방법이 있을 지 문의 드립니다.
+        출석 인정이 가능하다면 관련 서류를 발급 받을 수 있는지 확인해보고자 합니다.
+
+        항상 좋은 수업 감사합니다!
+        [본인이름] 드림
+      `);
+    }
+  }, [isKeywordSelected]);
+
+  return (
+    <PageWrapper>
+      <Sidebar />
+      <ContentWrapper>
+        <TemplateSidebar
+          selectedTarget={selectedTarget}
+          setSelectedTarget={setSelectedTarget}
+          selectedKeyword={selectedKeyword}
+          setSelectedKeyword={setSelectedKeyword}
+          selectedDetail={selectedDetail}
+          setSelectedDetail={setSelectedDetail}
+        />
+        {isKeywordSelected && <MailEditor templateContent={templateContent} />}
+      </ContentWrapper>
+    </PageWrapper>
+  );
+};
+
+export default TemplatePage;
+
+const PageWrapper = styled.div`
+  display: flex;
+  height: 100vh;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex: 1;
+`;


### PR DESCRIPTION
<img width="1710" alt="스크린샷 2025-03-25 오후 11 29 14" src="https://github.com/user-attachments/assets/a2b8bda8-ddef-4968-94ae-57cb3eaefbd1" />

템플릿 페이지 구현했습니다. 사이드바에서 대상 및 키워드와 세부키워드 선택 마치면 메일 편집 컴포넌트가 나옵니다.
현재는 사진처럼 임시 템플릿 넣어뒀습니다.